### PR TITLE
Set NewRelic appname

### DIFF
--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -9,7 +9,7 @@ function stanford_sites_systemtools_boot() {
   if (function_exists('newrelic_set_appname')) {
     $appname = check_plain(getcwd());
     $appname = preg_replace('/\/var\/www\//',"",$appname);
-    $appname = preg_replace('/\/public_html\//',"",$appname);
+    $appname = preg_replace('/\/public_html/',"",$appname);
     newrelic_set_appname($appname);
     variable_set('stanford_newrelic_appname',$appname);
   }

--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @file
+ * Code for the Stanford Sites System Tools module.
+ */
 
 /**
  * Implements hook_boot().
@@ -8,12 +12,13 @@
 function stanford_sites_systemtools_boot() {
   if (function_exists('newrelic_set_appname')) {
     $appname = check_plain(getcwd());
-    $appname = preg_replace('/\/var\/www\//',"",$appname);
-    $appname = preg_replace('/\/public_html\//',"",$appname);
+    $appname = preg_replace('/\/var\/www\//', "",$appname);
+    $appname = preg_replace('/\/public_html\//', "", $appname);
     newrelic_set_appname($appname);
-    variable_set('stanford_newrelic_appname',$appname);
+    variable_set('stanford_newrelic_appname', $appname);
   }
 }
+
 /**
  * Implements hook_form_FORM_ID_alter().
  */

--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Code for the Stanford Sites System Tools module.

--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -1,6 +1,20 @@
 <?php
 
 /**
+ * Implements hook_boot().
+ *
+ * Set the appname for NewRelic.
+ */
+function stanford_sites_systemtools_boot() {
+  if (function_exists('newrelic_set_appname')) {
+    $appname = check_plain(getcwd());
+    $appname = preg_replace('/\/var\/www\//',"",$appname);
+    $appname = preg_replace('/\/public_html\//',"",$appname);
+    newrelic_set_appname($appname);
+    variable_set('stanford_newrelic_appname',$appname);
+  }
+}
+/**
  * Implements hook_form_FORM_ID_alter().
  */
 function stanford_sites_systemtools_form_features_export_form_alter(&$form, &$form_state, $form_id) {


### PR DESCRIPTION
Two questions on this:

1. `hook_boot()` or `hook_init()`?
2. Is there a problem with running `variable_set()` during `hook_boot()`? It works, I'm just worried about the performance implications. Recommendations on a better approach are welcome; the goal is to have the `newrelic.appname` variable available to Drupal (so we can see what it's sending to NewRelic).