### PR TITLE
DRPL-478: Disable some form options

### DIFF
--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -34,7 +34,7 @@ function stanford_sites_systemtools_form_features_export_form_alter(&$form, &$fo
 /**
  * Implements hook_form_FORM_ID_alter().
  */
-function stanford_sites_systemtools_form_system_modules_alter(&$form, $form_state, $form_id) {
+function stanford_sites_systemtools_form_alter(&$form, $form_state, $form_id) {
   // Once enabled this module cannot be disabled (unless you get to the database or use Drush)
   // So evil.
   // Drush is run through the cli so we don't act if that's the interface being used

--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -70,7 +70,7 @@ function stanford_sites_systemtools_bam_validate($form, &$form_state) {
   }
   $directory_has_dots = preg_match('/\.\./', $location);
   if ($directory_has_dots == 1) {
-    form_set_error('location', t('You must enter a relative path for your destination directory.'));
+    form_set_error('location', t('You may not choose a destination outside of your Drupal directory.'));
   }
 }
 

--- a/stanford_sites_systemtools.module
+++ b/stanford_sites_systemtools.module
@@ -17,7 +17,7 @@ function stanford_sites_systemtools_form_features_export_form_alter(&$form, &$fo
 }
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Implements hook_form_alter().
  */
 function stanford_sites_systemtools_form_alter(&$form, $form_state, $form_id) {
   // Once enabled this module cannot be disabled (unless you get to the database or use Drush)


### PR DESCRIPTION
To test, on a fresh install of the `stanford` profile:
1. Check out `7.x-1.2`
2. Go to `admin/config/media/file-system`
3. See the options to change the file system paths
4. Go to `admin/config/system/backup_migrate/settings/destination/edit/manual`
5. Enter `/tmp` for Directory path
6. Save the destination
7. Destination saves correctly
8. Go to `admin/config/system/backup_migrate/settings/destination/edit/manual`
9. Enter `../../foo` for Directory path
10. Save the destination
11. Destination saves correctly
12. Check out the `DRPL-478` branch
13. Go to `admin/config/media/file-system`
14. See the options to change the file system paths
15. Go to `admin/config/system/backup_migrate/settings/destination/edit/manual`
16. Enter `/tmp` for Directory path
17. Save the destination
18. Get the error "You must enter a relative path for your destination directory."
19. Go to `admin/config/system/backup_migrate/settings/destination/edit/manual`
20. Enter `../../foo` for Directory path
21. Save the destination
22. Get the error "You may not choose a destination outside of your Drupal directory."
23. Go to `admin/modules`
24. The switches for the "External Repository Update Status", "PHP filter", "Stanford Sites System Tools", and "Update manager" modules should be disabled